### PR TITLE
Fixes path to stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <title>Tailwind Starter Template</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="/dist/styles.css">
+    <link rel="stylesheet" href="./dist/styles.css">
   </head>
   <body>
     <div class="min-h-screen flex items-center justify-center">


### PR DESCRIPTION
Updates the path of the stylesheet that it does also work locally.
When you use `/dist/styles.css` it does work, if you are on a server (or something like valet), but if you open the index.html simply in Chrome the style.css will result in a 404.

Using `./dist/styles.css` should work in both cases.