### PR TITLE
Fix for `npm run dev` problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "postcss-loader": "^2.1.1",
     "style-loader": "^0.20.3",
     "tailwindcss": ">=0.6.5",
-    "webpack": "^4.1.1",
-    "webpack-cli": "^2.0.12",
-    "webpack-dev-server": "^3.1.1"
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.9"
   }
 }


### PR DESCRIPTION
Webpack has chaged their definition from output to outputOptions in webpack/webpack#7232, [webpack/webpack@3a896c9#diff-03af1a9344cf93838ad925ff61de02aaL328](https://github.com/webpack/webpack/commit/3a896c96b64abb993b83f15dec460faf8d9bf2b3#diff-03af1a9344cf93838ad925ff61de02aaL328)

This is causing the the error shown below when trying to run `npm run dev` on this repo.

The recommended fix is to upgrade the `webpack-cli` dev dependency.

This PR has taken the oppourtunity to upgrade `webpack`, `webpack-cli` and `webpack-dev-server ` dev dependencies to get them all on the latest versions.

```
❯ npm run dev

> @ dev /Users/lee/Desktop/webpack-starter
> cross-env NODE_ENV=development webpack-dev-server

/Users/lee/Desktop/webpack-starter/node_modules/webpack-cli/bin/config-yargs.js:89
				describe: optionsSchema.definitions.output.properties.path.description,
				                                           ^

TypeError: Cannot read property 'properties' of undefined
    at module.exports (/Users/lee/code/webpack-starter/node_modules/webpack-cli/bin/config-yargs.js:89:48)
    at Object.<anonymous> (/Users/lee/code/webpack-starter/node_modules/webpack-dev-server/bin/webpack-dev-server.js:84:40)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:266:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:596:3)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @ dev: `cross-env NODE_ENV=development webpack-dev-server`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @ dev script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/lee/.npm/_logs/2018-10-17T12_42_04_824Z-debug.log
```