### PR TITLE
Fix TypeError: Cannot read property 'properties' of undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "postcss-loader": "^2.1.1",
     "style-loader": "^0.20.3",
     "tailwindcss": ">=0.6.5",
-    "webpack": "^4.1.1",
-    "webpack-cli": "^2.0.12",
+    "webpack": "^4.27.1",
+    "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.1"
   }
 }


### PR DESCRIPTION
Fix TypeError: Cannot read property 'properties' of undefined by updating to a newer version of webpack. Relatd to issue tailwindcss#20.