### PR TITLE
webpack-cli update

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "postcss-loader": "^2.1.1",
     "style-loader": "^0.20.3",
     "tailwindcss": ">=0.6.5",
-    "webpack": "^4.1.1",
-    "webpack-cli": "^2.0.12",
-    "webpack-dev-server": "^3.1.1"
+    
+    "webpack": "^4.28.3",
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.14"
   }
 }


### PR DESCRIPTION
webpack-cli ^3.1.2 and other updates to avoid this error:

webpack-starter/node_modules/webpack-cli/bin/config-yargs.js:89
				describe: optionsSchema.definitions.output.properties.path.description